### PR TITLE
🐛 FIX: Data replication in case of undo last commit

### DIFF
--- a/scripts/update-data-file.js
+++ b/scripts/update-data-file.js
@@ -20,14 +20,20 @@ const addNewPosts = (allStagedFiles, type) => {
 		);
 
 		const existingData = require(`../${type}/data.json`);
-		const newData = newDirectories.concat(existingData);
-		const data = JSON.stringify(newData);
-
-		fs.writeFileSync(`${cwd}/${type}/data.json`, data);
-
-		console.log(
-			`Data written to ${cwd}/${type}/data.json file for ${type}`
+		const dirExist = newDirectories.every(dir =>
+			existingData.includes(dir)
 		);
+
+		if (!dirExist) {
+			const newData = newDirectories.concat(existingData);
+			const data = JSON.stringify(newData);
+
+			fs.writeFileSync(`${cwd}/${type}/data.json`, data);
+
+			console.log(
+				`Data written to ${cwd}/${type}/data.json file for ${type}`
+			);
+		}
 	}
 };
 


### PR DESCRIPTION
If you undo the last commit that committed the guides and commits again, the sources get added again in the `data.json` file. This PR fixes this bug.

@ghoshnirmalya kindly take a look.