### PR TITLE
🐛 FIX: Code blocks and category

### DIFF
--- a/guides/data.json
+++ b/guides/data.json
@@ -1,4 +1,5 @@
 [
+	{"source": "graphql-subscriptions"},
 	{"source": "webgl"},
 	{"source": "url-pattern-api"},
 	{"source": "put-vs-patch"},
@@ -11,7 +12,6 @@
 	{"source": "build-screenshot-app"},
 	{"source": "practices-api-authentication"},
 	{"source": "practices-api-errors"},
-	{"source": "graphql-subscriptions"},
 	{"source": "encoding-api"},
 	{"source": "css-object-model-app"},
 	{"source": "channel-messaging-api"},

--- a/guides/posts/call-apis-svelte/post.md
+++ b/guides/posts/call-apis-svelte/post.md
@@ -59,14 +59,13 @@ If we put our API call inside the `onMount` hook of Svelte, the API request will
 
 To use `onMount` you need to import it in your Svelte file.
 
-```jsx
+```svelte
 import {onMount} from 'svelte';
 ```
 
 Now, you can use the hook inside the `<script>` tag like this:
 
-```jsx
-// index.svelte
+```svelte
 <script>
 	import {onMount} from 'svelte'; let footprint; onMount(); // Make the API
 	Call inside this hook
@@ -79,7 +78,7 @@ The `onMount` hook will send the API request whenever the component loads, but s
 
 In that case, we can use the event handlers like `on:click` to trigger our caller function:
 
-```jsx
+```svelte
 <script>
     import { onMount } from 'svelte';
     let footprint;
@@ -104,7 +103,7 @@ RapidAPI Hub automatically creates code snippets to request the API in multiple 
 
 I modified this snippet to use `await` and put it in an `async` function inside the `onMount` hook.
 
-```jsx
+```svelte
 <script>
     import { onMount } from 'svelte';
 
@@ -128,7 +127,7 @@ I modified this snippet to use `await` and put it in an `async` function inside 
 
 Finally, we can display the data returned by the API. Inside the `<script>` tag, we will create an empty variable `footprint`, and store the API response in this variable. The fun thing about Svelte is that we can use this variable straight away in our HTML like states in React. Here is the final code.
 
-```jsx
+```svelte
 <script>
     import { onMount } from 'svelte';
     let footprint;

--- a/guides/posts/graphql-apis-svelte/post.md
+++ b/guides/posts/graphql-apis-svelte/post.md
@@ -48,7 +48,8 @@ import {onMount} from 'svelte';
 
 Then, we can specify the query, and inside the `onMount` hook, we will create an async function that will send the request to the API.
 
-```jsx
+```svelte
+<script>
     import { onMount } from 'svelte';
     let country;
     let query = `{
@@ -74,7 +75,7 @@ Then, we can specify the query, and inside the `onMount` hook, we will create an
 
 You can see that we have created an empty variable `country`, and we are storing the API response in this variable. The fun thing about Svelte is that we can use this variable straight away in our HTML, so let's do that.
 
-```jsx
+```svelte
 <script>
     import { onMount } from 'svelte';
     let country;
@@ -130,14 +131,14 @@ npm install @apollo/client svelte-apollo graphql
 
 Next, import the following in your Svelte file.
 
-```jsx
+```svelte
 import {ApolloClient, gql} from '@apollo/client';
 import {setClient, getClient, query} from 'svelte-apollo';
 ```
 
 Then, inside the `<script>` tag, you can set up the Apollo Client like this:
 
-```jsx
+```svelte
 const client = new ApolloClient({
 	uri: 'https://geodb-cities-graphql.p.rapidapi.com/'
 });
@@ -146,13 +147,13 @@ setClient(client);
 
 If you want to access the client in any other component, you can do it by using the `getClient` function.
 
-```jsx
+```svelte
 const client = getClient();
 ```
 
 Finally, we can set up and send the query. We will use the same `onMount` hook to display the response. The final code will look like this:
 
-```jsx
+```svelte
 <script>
     import { ApolloClient, gql } from '@apollo/client';
     import { setClient, getClient, query } from 'svelte-apollo';

--- a/guides/posts/graphql-subscriptions/post.md
+++ b/guides/posts/graphql-subscriptions/post.md
@@ -1,10 +1,11 @@
 ---
-title: 'Introduction to GraphQL Subscriptions'
-description: 'GraphQL Subscriptions provide a way to fetch data from the server in real-time. A subscription is a continuously living request that pushes data to the client whenever a specific event happens.'
+title: Introduction to GraphQL Subscriptions
+description: GraphQL Subscriptions provide a way to fetch data from the server in real-time. A subscription is a continuously living request that pushes data to the client whenever a specific event happens.
 authors:
     - ahmadBilal
 categories:
-    - api
+    - interactive
+	- api
 tags:
     - graphql
     - api


### PR DESCRIPTION
This PR fixes the following:

- Code blocks in the Svelte guides.
- Adds the GraphQL Subscriptions guide to interactive category.

@ghoshnirmalya kindly take a look.