### PR TITLE
🐛 FIX: Formatting in HTTP cookie thread

### DIFF
--- a/threads/posts/http-cookie/post.md
+++ b/threads/posts/http-cookie/post.md
@@ -7,7 +7,7 @@ id: '1493525071893340160'
 ## What exactly is an HTTP Cookie.
 
 <Tweet>
-  
+
 Have you ever imagined how you stay logged in even after you close the tab?
 
 Or how do items stay in your cart when you refresh or close a tab?
@@ -23,7 +23,7 @@ HTTP cookies, also known as web cookies or browser cookies, are nothing but a pi
 </Tweet>
 
 <Tweet>
-  
+
 Although HTTP protocol itself is stateless, meaning no connection between two successive requests.
 
 But HTTP cookies allow us to store meaningful states.

--- a/threads/posts/rest-api/post.md
+++ b/threads/posts/rest-api/post.md
@@ -55,7 +55,7 @@ When you send a request to an endpoint, the server responds with the relevant da
 
 An actual RESTful API will follow the following constraints. 👇🏻
 
-1. Client-Server Architecture
+Client-Server Architecture
 
 The client requests the data from the server with no third-party interpretation.
   
@@ -63,7 +63,7 @@ The client requests the data from the server with no third-party interpretation.
 
 <Tweet>
 
-2. Statelessness
+Statelessness
 
 Statelessness means that every HTTP request happens in complete isolation. The client and the server don't need to store any information about each other, and there is no state.
   
@@ -71,7 +71,7 @@ Statelessness means that every HTTP request happens in complete isolation. The c
 
 <Tweet>
 
-3. Cacheability
+Cacheability
 
 The response can be cacheable, and it can improve the performance and scalability of an API. Also, cacheability allows the client to get the data even quicker.
   
@@ -79,7 +79,7 @@ The response can be cacheable, and it can improve the performance and scalabilit
 
 <Tweet>
 
-4. Layering
+Layering
 
 Different layers of the API architecture should work together, creating a scalable system that is easy to update or adjust.
   
@@ -87,7 +87,7 @@ Different layers of the API architecture should work together, creating a scalab
 
 <Tweet>
 
-5. Uniform Interface
+Uniform Interface
 
 Communication between the client and the server must be done in a standardized language that is independent of both. This improves scalability and flexibility.
   


### PR DESCRIPTION
Fixed empty spaces which are rendering an extra `p` tag.